### PR TITLE
Some miscellaneous fixes

### DIFF
--- a/src/components/HomePage/FAQSection.js
+++ b/src/components/HomePage/FAQSection.js
@@ -93,8 +93,8 @@ function FAQSection() {
 			answer:
 				<>
 					Don’t think it’s possible? Check out previous submissions from <Link
-						href='https://hoth6.devpost.com/submissions' >HOTH 6</Link>, <Link
-						href='https://hoth5.devpost.com/submissions' >HOTH 5</Link>, and <Link
+						href='https://hoth6.devpost.com/submissions'>HOTH 6</Link>, <Link
+						href='https://hoth5.devpost.com/submissions'>HOTH 5</Link>, and <Link
 						href='https://hoth4.devpost.com/submissions'>HOTH 4</Link>.
 				</>
 		}
@@ -116,7 +116,7 @@ function FAQSection() {
 						{question}
 					</Typography>
 				</ExpansionPanelSummary>
-				<ExpansionPanelDetails id={panelName + '-content'}>
+				<ExpansionPanelDetails>
 					<Typography variant='body1'>
 						{answer}
 					</Typography>
@@ -129,6 +129,7 @@ function FAQSection() {
 		<Container maxWidth='md'>
 			<Typography
 				variant='h5'
+				component='h2'
 				align='center'>
 				Frequently Asked Questions (FAQ)
 			</Typography>

--- a/src/components/HomePage/HothDescription.js
+++ b/src/components/HomePage/HothDescription.js
@@ -36,7 +36,7 @@ export default function HothDescription() {
 							variant={isSmall ? 'h4' : 'h3'}
 							className={classes.desc}
 							align={isSmall ? 'center' : 'right'}
-							component='h3'
+							component='h2'
 						>
 							What is Hack on the Hill?
 						</Typography>


### PR DESCRIPTION
They should not change the page display.

Other than the style fix, the changes fix some comments made by [Lighthouse][1]:

- Remove explicit and duplicate id from ExpansionPanelDetails, as an id   is already added by the framework.
- Change heading component to be semantically meaningful and independent   of the displayed variant. This establishes the rule that `<h1>` is the 	page heading, `<h2>` is a section in the page, etc.

[1]: https://developers.google.com/web/tools/lighthouse