### PR TITLE
Bump GitHub labeler to master

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@master
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
We are using `any` and `all`, features that only exist on the master branch of actions/labeler; see actions/labeler#73. Bump the action to master, thereby fixing this issue.

Fixes: #38