### PR TITLE
Improve default image quality

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -18,7 +18,12 @@ module.exports = {
 			}
 		},
 		'gatsby-transformer-sharp',
-		'gatsby-plugin-sharp',
+		{
+			resolve: 'gatsby-plugin-sharp',
+			options: {
+				defaultQuality: 96
+			}
+		},
 		{
 			resolve: 'gatsby-plugin-manifest',
 			/* eslint-disable camelcase */

--- a/src/components/GalleryPage/Gallery.js
+++ b/src/components/GalleryPage/Gallery.js
@@ -11,7 +11,7 @@ export default function Gallery() {
 					relativePath
 					childImageSharp {
 						fluid {
-							...GatsbyImageSharpFluid
+							...GatsbyImageSharpFluid_withWebp
 						}
 					}
 				}

--- a/src/components/GalleryPage/Winners.js
+++ b/src/components/GalleryPage/Winners.js
@@ -59,7 +59,7 @@ function Winners() {
 					relativePath
 					childImageSharp {
 						fluid {
-							...GatsbyImageSharpFluid
+							...GatsbyImageSharpFluid_withWebp
 						}
 					}
 				}

--- a/src/components/HomePage/Gallery.js
+++ b/src/components/HomePage/Gallery.js
@@ -12,7 +12,7 @@ export default function Gallery() {
 					relativePath
 					childImageSharp {
 						fluid {
-							...GatsbyImageSharpFluid
+							...GatsbyImageSharpFluid_withWebp
 						}
 					}
 				}

--- a/src/components/HomePage/HothDescription.js
+++ b/src/components/HomePage/HothDescription.js
@@ -53,14 +53,14 @@ export default function HothDescription() {
 			image1: file(relativePath: {eq: "hoth-description/IMG_1914.jpg"}) {
 				childImageSharp {
 					fluid {
-						...GatsbyImageSharpFluid
+						...GatsbyImageSharpFluid_withWebp
 					}
 				}
 			}
 			image2: file(relativePath: {eq: "hoth-description/IMG_2030.jpg"}) {
 				childImageSharp {
 					fluid {
-						...GatsbyImageSharpFluid
+						...GatsbyImageSharpFluid_withWebp
 					}
 				}
 			}


### PR DESCRIPTION
Fixes: #78 

Changes `gatsby-config.js` to increase the default quality value of images from 50 to 96. Additionally modifies the GrqphQL queries to use `_withWebP` as specified by the [gatsby-image documentation](https://www.gatsbyjs.com/plugins/gatsby-image/) in order to take advantage of the more efficient [WebP image format](https://en.wikipedia.org/wiki/WebP).
