### PR TITLE
Increase z-index of mobile menu bar

### DIFF
--- a/src/components/MenuBar/MenuBar.js
+++ b/src/components/MenuBar/MenuBar.js
@@ -38,7 +38,7 @@ const useStyles = makeStyles(theme => {
 		mobileMenuBar: {
 			boxShadow: theme.shadows[4],
 			position: 'fixed',
-			zIndex: '1',
+			zIndex: '10',
 			overflow: 'hidden',
 			backgroundColor: theme.palette.grey[100],
 			width: '100%'


### PR DESCRIPTION
The sticky header of the schedule page also has z-index: 1, causing conflicts with the menu bar.

Fixes: #118
