### PR TITLE
Fix workshop page container width

### DIFF
--- a/src/components/GalleryPage/Winners.js
+++ b/src/components/GalleryPage/Winners.js
@@ -83,10 +83,12 @@ function Winners() {
 				<hgroup>
 					<Typography variant='h5' component='h2'>{item.title}</Typography>
 					<Typography variant='subtitle1' component='h3'
-						style={{ fontWeight: theme.typography.fontWeightRegular,
+						style={{
 							textTransform: 'uppercase',
 							fontSize: '1em',
-							letterSpacing: '.5px' }}>
+							letterSpacing: '.5px'
+						}}
+					>
 						{item.category}
 					</Typography>
 				</hgroup>

--- a/src/components/WorkshopPage/Workshop.js
+++ b/src/components/WorkshopPage/Workshop.js
@@ -3,27 +3,23 @@ import ReactPlayer from 'react-player/youtube';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import useTheme from '@material-ui/core/styles/useTheme';
-import useMediaQuery from '@material-ui/core/useMediaQuery';
 import PropTypes from 'prop-types';
 
 function Workshop(props) {
-	const theme = useTheme();
-	const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
-
 	return (
-		<Grid key={props.title} item xs={12} sm={8} md={6}
-			style={{
-				paddingRight: theme.spacing(isSmall ? 4 : 8)
-			}}>
+		<Grid item xs={12} sm={8} md={6}>
 			<ReactPlayer
 				style={{ borderRadius: '10px', overflow: 'hidden' }}
 				controls={true} width='100%' url={props.url} />
-			<hgroup>
-				<Typography variant='h5' component='h5' style={{ paddingTop: '0.5em' }}>
+			<hgroup style={{ marginTop: '1em' }}>
+				<Typography variant='h5' component='h3'>
 					{props.title}
 				</Typography>
-				<Typography variant='h6' component='h6' style={{ paddingTop: '0.5em' }}>
+				<Typography variant='subtitle1' component='h4' style={{
+					textTransform: 'uppercase',
+					fontSize: '1em',
+					letterSpacing: '.5px'
+				}}>
 					{'Taught by: ' + props.author}
 				</Typography>
 			</hgroup>

--- a/src/components/WorkshopPage/WorkshopPage.js
+++ b/src/components/WorkshopPage/WorkshopPage.js
@@ -73,7 +73,7 @@ function WorkshopPage() {
 		</React.Fragment>);
 
 	return (
-		<Container maxWidth='lg' style={{ marginBottom: theme.spacing(8) }}>
+		<Container maxWidth='md' style={{ marginBottom: theme.spacing(8) }}>
 			<Typography variant='h3' component='h3'
 				style={{
 					fontWeight: theme.typography.fontWeightBold,

--- a/src/components/WorkshopPage/WorkshopPage.js
+++ b/src/components/WorkshopPage/WorkshopPage.js
@@ -65,16 +65,26 @@ function WorkshopPage() {
 				{item.type}
 			</Typography>
 
-			<Grid style={{ paddingBottom: theme.spacing(isSmall ? 4 : 8) }}>
-				<Grid container spacing={8} justify={isSmall ? 'center' : 'flex-start'}>
-					{item.elements.map(element => <Workshop key={element.title} {...element} />)}
-				</Grid>
+			<Grid
+				container
+				style={{
+					// This counteracts the negative margin Material-UI places on the Grid component, and
+					// hence acts as a small positive margin.
+					marginBottom: theme.spacing(isSmall ? 0 : 4),
+
+					// Material-UI's Grid seems to miscalculate the width, causing a spurious page overflow.
+					width: 'calc(100% + 56px)'
+				}}
+				spacing={8}
+				justify={isSmall ? 'center' : 'flex-start'}
+			>
+				{item.elements.map(element => <Workshop key={element.title} {...element} />)}
 			</Grid>
 		</React.Fragment>);
 
 	return (
 		<Container maxWidth='md' style={{ marginBottom: theme.spacing(8) }}>
-			<Typography variant='h3' component='h3'
+			<Typography variant='h3' component='h1'
 				style={{
 					fontWeight: theme.typography.fontWeightBold,
 					paddingTop: theme.spacing(isSmall ? 4 : 8),


### PR DESCRIPTION
The current workshop page is wrapped in a `Container` of size `lg` right now. Noticed because it causes awkward horizontal overflow on my laptop.

The rest of the website uses `md` for `Container` so I just changed it. 

Not sure if this fix is in another upcoming PR, but I didn't see any issue made for it, so I made this one just in case. Feel free to reject if another PR was going to fix this. 