### PR TITLE
Header/Footer takes up full page

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,4 +4,8 @@
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
 
-// You can delete this file if you're not using it
+/**
+ *
+ * set the global style such that the Gatsby divs are 100% page height.
+ */
+require('./src/styles/global.css');

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
-import { MuiThemeProvider, createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { MuiThemeProvider, createMuiTheme, responsiveFontSizes, makeStyles } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import grey from '@material-ui/core/colors/grey';
 
@@ -41,7 +41,23 @@ const overwrittenTheme = responsiveFontSizes(createMuiTheme({
 	}
 }));
 
+const useStyles = makeStyles(() => ({
+	wrapper: {
+		minHeight: '100%',
+		display: 'flex',
+		flexDirection: 'column'
+	},
+	headFooter: {
+		flexShrink: 0
+	},
+	main: {
+		flexGrow: 1
+	}
+}));
+
 const Layout = ({ children }) => {
+	const classes = useStyles();
+
 	return (
 		<MuiThemeProvider theme={overwrittenTheme}>
 			<CssBaseline />
@@ -49,9 +65,17 @@ const Layout = ({ children }) => {
 				<link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,600;0,700;1,700&display=swap" rel="stylesheet"/>
 				<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400&display=swap" rel="stylesheet"/>
 			</Helmet>
-			<MenuBar />
-			<main>{children}</main>
-			<Footer />
+			<div className={classes.wrapper}>
+				<header className={classes.headFooter}>
+					<MenuBar />
+				</header>
+				<main className={classes.main}>
+					{children}
+				</main>
+				<footer className={classes.headFooter}>
+					<Footer />
+				</footer>
+			</div>
 		</MuiThemeProvider>
 	);
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,17 @@
+/*
+ * Purpose:
+ * Assign height: "100%" to top of the gatsby tree
+ *
+*/
+
+html, body, #___gatsby {
+	height: 100%;
+}
+
+body {
+	margin: 0px;
+}
+
+div #gatsby-focus-wrapper {
+	height: 100%;
+}


### PR DESCRIPTION
Before, if there wasn't enough content on the page, the footer would high up on the page, rather than on the bottom.

This fix makes the page always take up _at least_ the height of a screen, regardless how much content is on the page.
