### PR TITLE
Add README and slides links to each workshop component

### DIFF
--- a/src/components/WorkshopPage/Workshop.js
+++ b/src/components/WorkshopPage/Workshop.js
@@ -13,7 +13,7 @@ import SlideshowIcon from '@material-ui/icons/Slideshow';
 const useStyles = makeStyles(theme => ({
 	button: {
 		textTransform: 'none',
-		padding: '4px 1.5em',
+		padding: theme.spacing(1, 3),
 		maxWidth: 'fit-content'
 	},
 	video: {
@@ -21,7 +21,7 @@ const useStyles = makeStyles(theme => ({
 		overflow: 'hidden'
 	},
 	title: {
-		marginTop: '1em'
+		marginTop: theme.spacing(2)
 	},
 	author: {
 		textTransform: 'uppercase',
@@ -29,8 +29,7 @@ const useStyles = makeStyles(theme => ({
 		letterSpacing: '.5px'
 	},
 	description: {
-		paddingTop: '0.5em',
-		paddingBottom: '0.5em'
+		padding: theme.spacing(1, 0)
 	},
 	icon: {
 		marginRight: theme.spacing(0.5)

--- a/src/components/WorkshopPage/Workshop.js
+++ b/src/components/WorkshopPage/Workshop.js
@@ -5,42 +5,73 @@ import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import YouTubeIcon from '@material-ui/icons/YouTube';
+import GitHubIcon from '@material-ui/icons/GitHub';
+import SlideshowIcon from '@material-ui/icons/Slideshow';
+
+const useStyles = makeStyles(theme => ({
+	button: {
+		textTransform: 'none',
+		padding: '4px 1.5em',
+		maxWidth: 'fit-content'
+	},
+	video: {
+		borderRadius: '10px',
+		overflow: 'hidden'
+	},
+	title: {
+		marginTop: '1em'
+	},
+	author: {
+		textTransform: 'uppercase',
+		fontSize: '1em',
+		letterSpacing: '.5px'
+	},
+	description: {
+		paddingTop: '0.5em',
+		paddingBottom: '0.5em'
+	},
+	icon: {
+		marginRight: theme.spacing(0.5)
+	}
+}));
 
 function Workshop({ title, youtube, author, description, readme, slides }) {
+	const classes = useStyles();
 	return (
 		<Grid item xs={12} sm={8} md={6}>
 			<ReactPlayer
-				style={{ borderRadius: '10px', overflow: 'hidden' }}
+				className={classes.video}
 				controls={true} width='100%' url={youtube} />
-			<hgroup style={{ marginTop: '1em' }}>
+			<hgroup className={classes.title}>
 				<Typography variant='h5' component='h3'>
 					{title}
 				</Typography>
-				<Typography variant='subtitle1' component='h4' style={{
-					textTransform: 'uppercase',
-					fontSize: '1em',
-					letterSpacing: '.5px'
-				}}>
+				<Typography variant='subtitle1' component='h4' className={classes.author}>
 					{'Taught by: ' + author}
 				</Typography>
 			</hgroup>
-			<Typography variant='body1' style={{ paddingTop: '0.5em', paddingBottom: '0.5em' }}>
+			<Typography variant='body1' className={classes.description}>
 				{description}
 			</Typography>
-			<Box component="span" display="flex" justifyContent="space-between">
-				<Button variant='contained' disableElevation color="secondary" component='a'
+			<Box component="span" display="flex" justifyContent="space-around">
+				<Button variant='text' disableElevation color="secondary" component='a'
 					href={youtube} target='_blank' rel='noreferrer noopener'
-					style={{ textTransform: 'none', padding: '4px 1.5em', maxWidth: 'fit-content' }}>
+					className={classes.button}>
+					<YouTubeIcon color="secondary" className={classes.icon} />
 					Video
 				</Button>
-				<Button variant='contained' disableElevation color="secondary" component='a'
+				<Button variant='text' disableElevation color="secondary" component='a'
 					href={readme} target='_blank' rel='noreferrer noopener'
-					style={{ textTransform: 'none', padding: '4px 1.5em', maxWidth: 'fit-content' }}>
+					className={classes.button}>
+					<GitHubIcon color="secondary" className={classes.icon} />
 					README
 				</Button>
-				<Button variant='contained' disableElevation color="secondary" component='a'
+				<Button variant='text' disableElevation color="secondary" component='a'
 					href={slides} target='_blank' rel='noreferrer noopener'
-					style={{ textTransform: 'none', padding: '4px 1.5em', maxWidth: 'fit-content' }}>
+					className={classes.button}>
+					<SlideshowIcon color="secondary" className={classes.icon} />
 					Slides
 				</Button>
 			</Box>

--- a/src/components/WorkshopPage/Workshop.js
+++ b/src/components/WorkshopPage/Workshop.js
@@ -3,6 +3,7 @@ import ReactPlayer from 'react-player/youtube';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
 import PropTypes from 'prop-types';
 
 function Workshop(props) {
@@ -10,7 +11,7 @@ function Workshop(props) {
 		<Grid item xs={12} sm={8} md={6}>
 			<ReactPlayer
 				style={{ borderRadius: '10px', overflow: 'hidden' }}
-				controls={true} width='100%' url={props.url} />
+				controls={true} width='100%' url={props.youtube} />
 			<hgroup style={{ marginTop: '1em' }}>
 				<Typography variant='h5' component='h3'>
 					{props.title}
@@ -26,11 +27,23 @@ function Workshop(props) {
 			<Typography variant='body1' style={{ paddingTop: '0.5em', paddingBottom: '0.5em' }}>
 				{props.description}
 			</Typography>
-			<Button variant='contained' disableElevation color="secondary" component='a'
-				href={props.url} target='_blank' rel='noreferrer noopener'
-				style={{ textTransform: 'none', padding: '4px 1.5em', maxWidth: 'fit-content' }}>
-				See Video
-			</Button>
+			<Box component="span" display="flex" justifyContent="space-between">
+				<Button variant='contained' disableElevation color="secondary" component='a'
+					href={props.youtube} target='_blank' rel='noreferrer noopener'
+					style={{ textTransform: 'none', padding: '4px 1.5em', maxWidth: 'fit-content' }}>
+					Video
+				</Button>
+				<Button variant='contained' disableElevation color="secondary" component='a'
+					href={props.readme} target='_blank' rel='noreferrer noopener'
+					style={{ textTransform: 'none', padding: '4px 1.5em', maxWidth: 'fit-content' }}>
+					README
+				</Button>
+				<Button variant='contained' disableElevation color="secondary" component='a'
+					href={props.slides} target='_blank' rel='noreferrer noopener'
+					style={{ textTransform: 'none', padding: '4px 1.5em', maxWidth: 'fit-content' }}>
+					Slides
+				</Button>
+			</Box>
 		</Grid>);
 }
 
@@ -38,7 +51,9 @@ export default Workshop;
 
 Workshop.propTypes = {
 	title: PropTypes.string.isRequired,
-	url: PropTypes.string.isRequired,
+	youtube: PropTypes.string.isRequired,
 	author: PropTypes.string.isRequired,
-	description: PropTypes.string.isRequired
+	description: PropTypes.string.isRequired,
+	readme: PropTypes.string.isRequired,
+	slides: PropTypes.string.isRequired
 };

--- a/src/components/WorkshopPage/Workshop.js
+++ b/src/components/WorkshopPage/Workshop.js
@@ -6,48 +6,46 @@ import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 import PropTypes from 'prop-types';
 
-function Workshop(props) {
+function Workshop({ title, youtube, author, description, readme, slides }) {
 	return (
 		<Grid item xs={12} sm={8} md={6}>
 			<ReactPlayer
 				style={{ borderRadius: '10px', overflow: 'hidden' }}
-				controls={true} width='100%' url={props.youtube} />
+				controls={true} width='100%' url={youtube} />
 			<hgroup style={{ marginTop: '1em' }}>
 				<Typography variant='h5' component='h3'>
-					{props.title}
+					{title}
 				</Typography>
 				<Typography variant='subtitle1' component='h4' style={{
 					textTransform: 'uppercase',
 					fontSize: '1em',
 					letterSpacing: '.5px'
 				}}>
-					{'Taught by: ' + props.author}
+					{'Taught by: ' + author}
 				</Typography>
 			</hgroup>
 			<Typography variant='body1' style={{ paddingTop: '0.5em', paddingBottom: '0.5em' }}>
-				{props.description}
+				{description}
 			</Typography>
 			<Box component="span" display="flex" justifyContent="space-between">
 				<Button variant='contained' disableElevation color="secondary" component='a'
-					href={props.youtube} target='_blank' rel='noreferrer noopener'
+					href={youtube} target='_blank' rel='noreferrer noopener'
 					style={{ textTransform: 'none', padding: '4px 1.5em', maxWidth: 'fit-content' }}>
 					Video
 				</Button>
 				<Button variant='contained' disableElevation color="secondary" component='a'
-					href={props.readme} target='_blank' rel='noreferrer noopener'
+					href={readme} target='_blank' rel='noreferrer noopener'
 					style={{ textTransform: 'none', padding: '4px 1.5em', maxWidth: 'fit-content' }}>
 					README
 				</Button>
 				<Button variant='contained' disableElevation color="secondary" component='a'
-					href={props.slides} target='_blank' rel='noreferrer noopener'
+					href={slides} target='_blank' rel='noreferrer noopener'
 					style={{ textTransform: 'none', padding: '4px 1.5em', maxWidth: 'fit-content' }}>
 					Slides
 				</Button>
 			</Box>
 		</Grid>);
 }
-
-export default Workshop;
 
 Workshop.propTypes = {
 	title: PropTypes.string.isRequired,
@@ -57,3 +55,5 @@ Workshop.propTypes = {
 	readme: PropTypes.string.isRequired,
 	slides: PropTypes.string.isRequired
 };
+
+export default Workshop;

--- a/src/components/WorkshopPage/WorkshopPage.js
+++ b/src/components/WorkshopPage/WorkshopPage.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import Container from '@material-ui/core/Container';
+// import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import useTheme from '@material-ui/core/styles/useTheme';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
+// import Workshop from './Workshop.js';
 import ComingSoon from '../ComingSoon/ComingSoon';
 
 function WorkshopPage() {

--- a/src/components/WorkshopPage/WorkshopPage.js
+++ b/src/components/WorkshopPage/WorkshopPage.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import Container from '@material-ui/core/Container';
-// import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import useTheme from '@material-ui/core/styles/useTheme';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-// import Workshop from './Workshop.js';
 import ComingSoon from '../ComingSoon/ComingSoon';
+
 
 function WorkshopPage() {
 	const theme = useTheme();

--- a/src/components/WorkshopPage/WorkshopPage.js
+++ b/src/components/WorkshopPage/WorkshopPage.js
@@ -5,7 +5,6 @@ import useTheme from '@material-ui/core/styles/useTheme';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import ComingSoon from '../ComingSoon/ComingSoon';
 
-
 function WorkshopPage() {
 	const theme = useTheme();
 	const isSmall = useMediaQuery(theme.breakpoints.down('sm'));


### PR DESCRIPTION
Put links in buttons next to the previous "See Video" button. Put buttons in Box component to align them center to the column the workshop is in and make buttons equidistant from each other no matter what size the viewing window is.
Fixes #164