### PR TITLE
Changed schedule page tab title to 'Schedule'

### DIFF
--- a/src/pages/schedule.js
+++ b/src/pages/schedule.js
@@ -7,7 +7,7 @@ import Schedule from '../components/SchedulePage/Schedule';
 
 const SchedulePage = () => {
 	return <Layout>
-		<SEO title='Workshop schedule' />
+		<SEO title='Schedule' />
 		<Schedule/>
 	</Layout>;
 };


### PR DESCRIPTION
Changed the schedule page tab title from 'Workshop Schedule' to 'Schedule'.

Fixes #212 