### PR TITLE
Fixed MenuBar collapse threshold

### DIFF
--- a/src/components/MenuBar/MenuBar.js
+++ b/src/components/MenuBar/MenuBar.js
@@ -56,7 +56,7 @@ function MenuBar() {
 	const theme = useTheme();
 	const [menuOpen, setMenuOpen] = useState(false);
 	const toggleMenu = () => setMenuOpen(open => !open);
-	const isMobile = useMediaQuery(theme.breakpoints.down(theme.breakpoints.values.sm * 1.3));
+	const isMobile = useMediaQuery(theme.breakpoints.down(theme.breakpoints.values.sm * 1.8));
 
 	const wordmark = useMediaQuery(theme.breakpoints.down('xs')) ? 'HOTH' : 'Hack on the Hill';
 


### PR DESCRIPTION
Changed the threshold for isMobile so that the MenuBar collapses before the buttons get crunched and a second row is created. 