### PR TITLE
Fix collaborator issue with Github Actions

### DIFF
--- a/.github/workflows/announcements.yml
+++ b/.github/workflows/announcements.yml
@@ -9,7 +9,8 @@ jobs:
       github.event.issue.number == 181 &&
       (github.event.comment.author_association == 'OWNER' ||
       github.event.comment.author_association == 'MEMBER' ||
-      github.event.comment.author_association == 'CONTRIBUTOR')
+      github.event.comment.author_association == 'CONTRIBUTOR' ||
+      github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/update_announcements.py
+++ b/update_announcements.py
@@ -10,7 +10,7 @@ import sys
 import os
 
 # User whitelist and issue number we are looking for
-user_whitelist = ['jodymlin', 'khxia', 'jakobreinwald', 'christinatong01', 'milesswu']
+user_whitelist = ['jodymlin', 'khxia', 'jakobreinwald', 'christinatong01', 'milesswu', 'EinarBalan']
 # HOTH repository issues accessed via Github API
 repo_issues = "https://api.github.com/repos/uclaacm/hoth.uclaacm.com/issues"
 
@@ -36,6 +36,7 @@ valid_comments = []
 for index, element in enumerate(announcements_json):
     if element['user']['login'] in user_whitelist:
         body = element['body']
+				# If there is no partition, subject will contain the entire string
         subject, partition, comment = body.partition('(Subject) ')
         comment = {'id': index, 'subject': subject, 'body': comment, 'timestamp': element['created_at']}
         valid_comments.append(comment)


### PR DESCRIPTION
When christina added a comment on the issue, the job was skipped. I'm suspecting, based on this [post](https://github.community/t/github-actions-have-me-as-contributor-role-when-im-owner/138933/5) that we should add the 'collaborator' enum to the check as well. 