### PR TITLE
Nishant/Fix Hoth Banner Subtext Positioning

### DIFF
--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -32,7 +32,6 @@
 	display: flex;
 	justify-content: center;
 	width: 100%;
-	position: relative;
 	aspect-ratio: 2.5 / 1;
 	background-color: var(--bgGray);
 }


### PR DESCRIPTION
## Overview
- Seems like a previous commit offset the HOTH banner subtext slightly which affected how it looks on mobile screen sizes
- Fixes #492 

## All Changes
- Removed the line that set the `banner-container` to have `position: relative`
    - This was added by @aroy23 for some lazy loading bug but the bug seems to have been fixed by something else after we looked at it together so we decided it's not necessary anymore (see #463)

## New Bugs/Issues
- None

## Other information
- None