### PR TITLE
Nishant/Move theme toggle on mobile

### DIFF
--- a/src/components/General/DarkModeToggle.jsx
+++ b/src/components/General/DarkModeToggle.jsx
@@ -40,10 +40,6 @@ export default function DarkModeToggle() {
         checked={isDark}
         aria-label='Dark mode toggle'
         handleDiameter={32}
-        // offColor="#FAE9B1"
-        // onColor="#092E40"
-        // offHandleColor="#F3C136"
-        // onHandleColor="#2BADE7"
         offColor="#faddff"
         onColor="#3e2961"
         offHandleColor="#fca3fc"

--- a/src/components/General/Navbar.jsx
+++ b/src/components/General/Navbar.jsx
@@ -51,10 +51,13 @@ export default function Navbar() {
 				<h1>Hack on the Hill</h1>
 			</Link>
 
-			{/* Show hamburger only when isMobile is true (screen width <= 1000px) */}
+			{/* Show theme toggler and hamburger on navbar only when isMobile is true (screen width <= 1000px) */}
 			{isMobile && (
-				<div className='hamburger' onClick={toggleMenu}>
-					<Menu size={32} />
+				<div className='mobile-nav-container'>
+					<DarkModeToggle />
+					<div className='hamburger' onClick={toggleMenu}>
+						<Menu size={32} />
+					</div>
 				</div>
 			)}
 
@@ -91,9 +94,11 @@ export default function Navbar() {
 						GALLERY
 					</Link>
 				</li>
-				<li>
-					<DarkModeToggle />
-				</li>
+				{!isMobile && (
+					<li>
+						<DarkModeToggle />
+					</li>
+				)}
 				<li>
 					<a
 						href='https://forms.gle/HbxpV3dDnVExy1F3A'

--- a/src/styles/DarkModeToggle.css
+++ b/src/styles/DarkModeToggle.css
@@ -12,7 +12,16 @@
 
 @media (max-width: 1000px) {
 	.toggle {
+		width: 5.5rem;
 		padding-top: 0.5rem;
 		height: 3rem;
+	}
+}
+
+@media (max-width: 460px) {
+	.toggle {
+		padding-left: 0;
+		transform: scale(0.8);
+		width: 4rem;
 	}
 }

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -73,6 +73,11 @@
 	margin-left: 1rem;
 }
 
+.mobile-nav-container {
+	display: flex;
+	flex-direction: row;
+}
+
 /* Hamburger Menu Styles */
 .hamburger {
 	display: none;
@@ -101,9 +106,28 @@ a.apply-inactive {
 	margin-left: 0.4rem;
 }
 
+@media (max-width: 1300px) {
+	.navbar {
+		padding: 1rem 1rem 0.75rem;
+	}
+
+	.nav-hack h1 {
+		font-size: 1.25rem;
+	}
+
+	.navbar-links a {
+		font-size: 0.9rem;
+		padding: 0.5rem 0.75rem;
+	}
+}
+
 @media (max-width: 1000px) {
 	.navbar {
 		padding: 1rem 2rem;
+	}
+
+	.nav-hack h1 {
+		font-size: 1.5rem;
 	}
 
 	.navbar-links {
@@ -152,9 +176,9 @@ a.apply-inactive {
 	}
 }
 
-@media (max-width: 400px) {
+@media (max-width: 460px) {
 	.navbar {
-		padding: 0.75rem;
+		padding: 0.25rem 0.75rem;
 	}
 
 	.nav-hack-logo {
@@ -172,5 +196,11 @@ a.apply-inactive {
 
 	.navbar-links.active {
 		top: 3.5rem;
+	}
+}
+
+@media (max-width: 320px) {
+	.nav-hack h1 {
+		font-size: 0.85rem;
 	}
 }


### PR DESCRIPTION
## Overview
- On mobile screens, I moved the theme toggler switch to be next to the hamburger in the navbar, instead of being in the `navbar-links` dropdown, and I fixed some small navbar positioning bugs on different screen sizes.
- Fixes #494 

## All Changes
- Added the theme toggle switch component next to the hamburger when `isMobile` is true into a new div `mobile-nav-container` in `src/components/General/Navbar.jsx`
- Hid the toggler in the normal `navbar-links` list when `isMobile` is false in `src/components/General/Navbar.jsx`
- Removed comments that had old theme toggle switch colors in `src/components/General/DarkModeToggle.jsx`
- Made the toggler appropriately smaller when the screen size is small enough in `src/styles/DarkModeToggle.css`
- Added styling for new `mobile-nav-container` div in `src/components/General/Navbar.jsx`
- Adjusted sizing of navbar elements for different screen sizes to prevent overlapping (due to addition of the apply button in the navbar)

## New Bugs/Issues
- None

## Other information
- None