### PR TITLE
Import Winners Carousel Images Dynamically

### DIFF
--- a/src/components/Gallery/PhotoCarousel.jsx
+++ b/src/components/Gallery/PhotoCarousel.jsx
@@ -1,46 +1,14 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import '../../styles/Gallery.css';
 
-import hoth3_image1 from '../../images/gallery-carousel/hoth-3/image1.jpg';
-import hoth3_image2 from '../../images/gallery-carousel/hoth-3/image2.jpg';
-import hoth3_image3 from '../../images/gallery-carousel/hoth-3/image3.jpg';
-import hoth3_image4 from '../../images/gallery-carousel/hoth-3/image4.jpg';
-import hoth3_image5 from '../../images/gallery-carousel/hoth-3/image5.jpg';
-import hoth3_image6 from '../../images/gallery-carousel/hoth-3/image6.jpg';
-import hoth3_image7 from '../../images/gallery-carousel/hoth-3/image7.jpg';
-import hoth3_image8 from '../../images/gallery-carousel/hoth-3/image8.jpg';
-
-import hoth7_image1 from '../../images/gallery-carousel/hoth-7/image1.jpg';
-import hoth7_image2 from '../../images/gallery-carousel/hoth-7/image2.jpg';
-import hoth7_image3 from '../../images/gallery-carousel/hoth-7/image3.jpg';
-import hoth7_image4 from '../../images/gallery-carousel/hoth-7/image4.jpg';
-import hoth7_image5 from '../../images/gallery-carousel/hoth-7/image5.jpg';
-import hoth7_image6 from '../../images/gallery-carousel/hoth-7/image6.jpg';
-import hoth7_image7 from '../../images/gallery-carousel/hoth-7/image7.jpg';
-import hoth7_image8 from '../../images/gallery-carousel/hoth-7/image8.jpg';
-import hoth7_image9 from '../../images/gallery-carousel/hoth-7/image9.jpg';
-
-import hoth9_image1 from '../../images/gallery-carousel/hoth-9/image1.jpg';
-import hoth9_image2 from '../../images/gallery-carousel/hoth-9/image2.jpg';
-import hoth9_image3 from '../../images/gallery-carousel/hoth-9/image3.jpg';
-
-import hothX_image1 from '../../images/gallery-carousel/hoth-X/image1.jpg';
-import hothX_image2 from '../../images/gallery-carousel/hoth-X/image2.jpg';
-import hothX_image3 from '../../images/gallery-carousel/hoth-X/image3.jpg';
-import hothX_image4 from '../../images/gallery-carousel/hoth-X/image4.jpg';
-import hothX_image5 from '../../images/gallery-carousel/hoth-X/image5.jpg';
-
-import hothXI_image1 from '../../images/gallery-carousel/hoth-XI/image1.jpg';
-import hothXI_image2 from '../../images/gallery-carousel/hoth-XI/image2.jpg';
-import hothXI_image3 from '../../images/gallery-carousel/hoth-XI/image3.jpg';
-import hothXI_image4 from '../../images/gallery-carousel/hoth-XI/image4.jpg';
-import hothXI_image5 from '../../images/gallery-carousel/hoth-XI/image5.jpg';
-import hothXI_image6 from '../../images/gallery-carousel/hoth-XI/image6.jpg';
+const imageFiles = import.meta.glob('../../images/gallery-carousel/hoth-*/image*.jpg');
 
 export default function PhotoCarousel({year}) {
+	const [images, setImages] = useState([]);
+	
 	const settings = {
 		dots: true,
 		infinite: true,
@@ -50,19 +18,32 @@ export default function PhotoCarousel({year}) {
 		className: '.slides',
 	};
 
-	let images = [];
+	useEffect(() => {
+		const loadImages = async () => {
+			setImages([]);
+			
+			const yearPattern = `/hoth-${year}/`;
+			const yearImages = Object.keys(imageFiles)
+				.filter(path => path.includes(yearPattern))
+				.sort();
 
-	if (year === '3') {
-		images = [hoth3_image1, hoth3_image2, hoth3_image3, hoth3_image4, hoth3_image5, hoth3_image6, hoth3_image7, hoth3_image8];
-	} else if (year === '7') {
-		images = [hoth7_image1, hoth7_image2, hoth7_image3, hoth7_image4, hoth7_image5, hoth7_image6, hoth7_image7, hoth7_image8, hoth7_image9];
-	} else if (year === '9') {
-		images = [hoth9_image1, hoth9_image2, hoth9_image3];
-	} else if (year === 'X') {
-		images = [hothX_image1, hothX_image2, hothX_image3, hothX_image4, hothX_image5];
-	} else if (year === 'XI') {
-		images = [hothXI_image1, hothXI_image2, hothXI_image3, hothXI_image4, hothXI_image5, hothXI_image6];
-	}
+			const loadedImages = await Promise.all(
+				yearImages.map(async (path) => {
+					try {
+						const module = await imageFiles[path]();
+						return module.default;
+					} catch (err) {
+						console.error(`Failed to load image ${path}:`, err);
+						return undefined;
+					}
+				})
+			);
+
+			setImages(loadedImages.filter(img => img !== undefined));
+		};
+
+		loadImages();
+	}, [year]);
 
 	return (
 		<Slider {...settings}>

--- a/src/components/Gallery/PhotoCarousel.jsx
+++ b/src/components/Gallery/PhotoCarousel.jsx
@@ -29,17 +29,12 @@ export default function PhotoCarousel({year}) {
 
 			const loadedImages = await Promise.all(
 				yearImages.map(async (path) => {
-					try {
-						const module = await imageFiles[path]();
-						return module.default;
-					} catch (err) {
-						console.error(`Failed to load image ${path}:`, err);
-						return undefined;
-					}
+					const module = await imageFiles[path]();
+					return module.default;
 				})
 			);
 
-			setImages(loadedImages.filter(img => img !== undefined));
+			setImages(loadedImages.filter(Boolean));
 		};
 
 		loadImages();

--- a/src/components/Gallery/Winner.jsx
+++ b/src/components/Gallery/Winner.jsx
@@ -1,14 +1,17 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import '../../styles/Gallery.css';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 
 export default function Winner({ year, appName, description, category, image, link}) {
-
     const [currentImage, setCurrentImage] = React.useState(null);
     
-    import(`../../images/gallery-winners/hoth-${year}/${image}.png`).then((image) => {
-        setCurrentImage(image.default);
-    });
+    useEffect(() => {
+        import(`../../images/gallery-winners/hoth-${year}/${image}.png`)
+            .then((image) => {
+                setCurrentImage(image.default);
+            })
+            .catch(err => console.error(`Failed to load winner image: ${image}`, err));
+    }, [year, image]);
     
     return (
         <div className='winner-container'>

--- a/src/components/Gallery/Winner.jsx
+++ b/src/components/Gallery/Winner.jsx
@@ -9,8 +9,7 @@ export default function Winner({ year, appName, description, category, image, li
         import(`../../images/gallery-winners/hoth-${year}/${image}.png`)
             .then((image) => {
                 setCurrentImage(image.default);
-            })
-            .catch(err => console.error(`Failed to load winner image: ${image}`, err));
+            });
     }, [year, image]);
     
     return (


### PR DESCRIPTION
## Overview
- Added dynamic imports to winners photo carousel on the gallery page and added a useEffect to Winner.jsx to prevent unnecessary rerenders
- Fixes #468

## All Changes
- For the photo carousel: loads all relevant image files and filters them by year prop
- For Winner.jsx simply added a useEffect