### PR TITLE
Nishant/Fixed spacing typo in HothDescription.jsx

### DIFF
--- a/src/components/Home/HothDescription.jsx
+++ b/src/components/Home/HothDescription.jsx
@@ -57,8 +57,8 @@ export default function HothDescription() {
 					/>
 				</div>
 				<p className='img-right-p'>
-					During HOTH, you&apos;ll get to learn from <strong>workshops</strong>, receive technical help from <strong>mentors</strong>, and meet new people while participating in <strong>fun</strong>
-					social activities. There will be <strong>prizes</strong> for the best hacks!
+					During HOTH, you&apos;ll get to learn from <strong>workshops</strong>, receive technical help from <strong>mentors</strong>, 
+					and meet new people while participating in <strong>fun</strong> social activities. There will be <strong>prizes</strong> for the best hacks!
 				</p>
 			</div>
 


### PR DESCRIPTION
## Overview
- Resolved a typo in the second description paragraph in home page
- Fixes #530 

## All Changes
- Just added a space and a line break to resolve the typo and have the description paragraph appear to be cleaner in the code

## New Bugs/Issues
- None

## Other information
- None