### PR TITLE
Consistent workshop video sizes before and after loading the YouTube player element

### DIFF
--- a/src/components/Workshops/Workshop.jsx
+++ b/src/components/Workshops/Workshop.jsx
@@ -32,11 +32,11 @@ export default function Workshop({ title, youtube, author, description, readme, 
                     <>
                         <LazyLoadImage
                             className='video-thumbnail'
-                            src={`https://img.youtube.com/vi/${youtube.split('/').pop()}/0.jpg`}
+                            src={`https://img.youtube.com/vi/${youtube.split('/').pop()}/maxresdefault.jpg`}
                             alt={title}
                             effect='blur'
                             width='100%'
-                            height='auto'
+                            height='100%'
                             onClick={() => setIsPlayerVisible(true)}
                         />
                         <div 
@@ -54,6 +54,7 @@ export default function Workshop({ title, youtube, author, description, readme, 
                         id={'id_' + title.replace(/ /g, '_')}
                         controls={true}
                         width='100%'
+                        height='100%'
                         url={youtube}
                     />
                 )}

--- a/src/styles/Workshops.css
+++ b/src/styles/Workshops.css
@@ -91,9 +91,12 @@
 }
 
 .workshop-video {
+    position: absolute;
     border-radius: var(--rounded-lg);
     overflow: hidden;
     width: 100%;
+    top: 0;
+    left: 0;
 }
 
 .workshop-header {
@@ -184,13 +187,16 @@
     width: 100%;
     border-radius: var(--rounded-lg);
     overflow: hidden;
-    line-height: 0;
+    aspect-ratio: 16/9;
 }
 
 .video-thumbnail {
+    position: absolute;
     width: 100%;
     cursor: pointer;
     display: block;
+    top: 0;
+    left: 0;
 }
 
 .video-overlay {
@@ -203,7 +209,7 @@
     align-items: center;
     justify-content: center;
     background: rgba(0, 0, 0, 0);
-    transition: background 0.2s;
+    transition: all 0.2s;
 }
 
 .video-overlay:hover {


### PR DESCRIPTION
## Overview
- Resolves the issue where the video thumbnail had a different height than the YouTube player element that gets loaded after clicking the thumbnail
- Fixes #536 

## All Changes
- Made sure `.video-thumbnail` and `.workshop-video` has `100%` height to ensure it fills up its allocated height
- Changed the `LazyLoadImage` `src` to be the highest resolution thumbnail image of each YouTube video, which doesn't have the ugly black bars on the top and bottom of it
- Added CSS styling in `Workshops.css` so that `.video-container` has an `aspect-ratio` of `16/9`, which ensures the container always has the same aspect ratio and thus both `.video-thumbnail` and `.workshop-video` adhere to that same aspect ratio
    - This also works with the dynamic grid we have set for each `.workshops-container`
- Changed the `transition` property to `all` to remove the error that was being shown for `background`

## New Bugs/Issues
- None

## Other information
- Kinda used this for help with the aspect ratio stuff: https://css-tricks.com/aspect-ratio-boxes/