### PR TITLE
Style navbar links: lowercase text, bolder weight, and more visible ho...

### DIFF
--- a/src/components/General/Navbar.jsx
+++ b/src/components/General/Navbar.jsx
@@ -65,32 +65,27 @@ export default function Navbar() {
 			<ul className={`navbar-links ${isOpen ? 'active' : ''}`}>
 				<li>
 					<Link to='/' onClick={closeMenu}>
-						HOME
+						Home
 					</Link>
 				</li>
 				<li>
 					<Link to='/announcements' onClick={closeMenu}>
-						ANNOUNCEMENTS
+						Announcements
 					</Link>
 				</li>
 				<li>
 					<Link to='/schedule' onClick={closeMenu}>
-						SCHEDULE
+						Schedule
 					</Link>
 				</li>
-				{/* <li>
-					<Link to='/workshops' onClick={closeMenu}>
-						WORKSHOPS
-					</Link>
-				</li> */}
 				<li>
 					<Link to='/prizes' onClick={closeMenu}>
-						PRIZES
+						Prizes
 					</Link>
 				</li>
 				<li>
 					<Link to='/gallery' onClick={closeMenu}>
-						GALLERY
+						Gallery
 					</Link>
 				</li>
 				{!isMobile && (
@@ -105,7 +100,7 @@ export default function Navbar() {
 						target='_blank'
 						rel='noopener noreferrer'
 					>
-						APPLY
+						Apply
 					</a>
 				</li>
 			</ul>

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -21,6 +21,7 @@
 	--offBlack: #333;
 	--shadow: rgba(0, 0, 0, 0.2);
 	--lightShadow: rgba(0, 0, 0, 0.08);
+	--navHover: #f0e6ff;
 
 	--hackPrimary: #c960ff;
 	--hackSecondaryV1: #c137d8;
@@ -54,6 +55,7 @@
 	--offBlack: #d4d4d4;
 	--shadow: rgba(255, 255, 255, 0.2);
 	--lightShadow: rgba(255, 255, 255, 0.08);
+	--navHover: rgba(201, 96, 255, 0.2);
 
 	--hackPrimary: #c960ff;
 	--hackSecondaryV1: #c137d8;

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -57,16 +57,15 @@
 	text-decoration: none;
 	color: var(--bgBlack);
 	font-size: 1rem;
-	font-weight: 200;
-	transition: color 0.5s ease;
-	transition: background-color 0.5s ease;
+	font-weight: 500;
+	transition: color 0.3s ease, background-color 0.3s ease;
 	padding: 0.5rem 1rem;
 	border-radius: var(--rounded-lg);
 }
 
 .navbar-links a:hover {
-	color: var(--darkPink);
-	background-color: var(--bgGray);
+	color: var(--hackPrimary);
+	background-color: var(--navHover);
 }
 
 .discord {


### PR DESCRIPTION
## Overview              
  - Style navbar links to be more readable and visually consistent with the rest of the site
  - Fixes #577                                                                               
   
  ## All Changes                                                                                              
  - **Lowercase link text**: Changed navbar link text from ALL CAPS to title case (e.g. "HOME" → "Home") to
  match the "Hack on the Hill" title style
  - **Bolder font weight**: Increased `font-weight` from `200` to `500` so the links are more legible and use
  a weight actually included in the Poppins font import
  - **More distinct hover state**: Added a new `--navHover` CSS variable with a soft lavender (`#f0e6ff`) for
  light mode and a semi-transparent purple (`rgba(201, 96, 255, 0.2)`) for dark mode, replacing the previous
  `--bgGray` which was too subtle in both themes
  - **Hover text color**: Changed hover text color from `--darkPink` to `--hackPrimary` to better match the
  HOTH brand palette
  - **Fixed CSS transition bug**: The two separate `transition` declarations in `.navbar-links a` were
  colliding (second overrode the first), combined them into a single declaration

  ## Other information
  - All changes are CSS/JSX only — no logic or dependency changes
  - Build and lint both pass cleanly
  
## Before
<img width="1710" height="1107" alt="Screenshot 2026-02-23 at 3 49 57 PM" src="https://github.com/user-attachments/assets/970b5b74-f720-4f62-b849-398d4704ca1c" />

## After
<img width="1710" height="1107" alt="Screenshot 2026-02-23 at 3 49 43 PM" src="https://github.com/user-attachments/assets/4974c74b-b715-4fb2-b480-af48728c1cc2" />

  